### PR TITLE
Drop 2015 parser option

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,6 @@ module.exports = {
       ],
       parserOptions: {
         sourceType: 'script',
-        ecmaVersion: 2015
       },
       env: {
         browser: false,


### PR DESCRIPTION
It's no longer in the ember blueprint and was fairly outdated.